### PR TITLE
Fix flaws and code smells

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,87 @@
 # Schwarz IT Code Review Repository
 
-This repository is meant to be used in the onboarding process of Go developers
-applying to Schwarz IT.
+API SERVICE for managing discount coupons. 
 
-Code smells and security issues are made on purpose. All the code to be reviewed is
-in the [review](review) directory.
+# Starting the project 
 
+- Without docker: 
 
+Just go in review/cmd/coupon_service and run `go run main.go`
+
+- Using docker:
+
+1. Build the docker image:
+
+```sh
+docker build -t coupon_api_service .
+```
+
+2. Run it 
+
+```sh
+docker run -p 8080:8080 coupon-service
+```
+
+Voila! You can see the server running at `http://localhost:8080`
+
+## API
+
+Below is a list of API endpoints with their respective input and output.
+
+### Creating coupons
+
+#### Endpoint
+
+```
+POST
+/api/coupon/create
+```
+
+#### Input
+
+```json
+{
+    "Discount": <int>,
+    "Code": <string>,
+    "MinBasketValue": <int>
+}
+```
+
+### Listing coupons
+
+#### Endpoint
+
+```
+GET
+/api/coupon/list
+```
+
+#### Input
+
+```json
+{
+  "Codes": [<string>, <string>, <string>]
+}
+```
+
+### Apply coupon value
+
+#### Endpoint
+
+```
+POST
+/api/coupon/apply
+```
+
+#### Input
+
+```json
+{
+  "Code": <string>,
+  "Basket": {
+    "Value"                 <int>
+	"AppliedDiscount"       <int>
+	"ApplicationSuccessful" <bool>
+  }
+}
+```

--- a/review/Dockerfile
+++ b/review/Dockerfile
@@ -1,14 +1,16 @@
 # build stage
 FROM golang:latest AS builder
 
-RUN apk add git gcc libc-dev
+RUN apt-get update && \
+    apt-get -y install gcc libc-dev 
 
-WORKDIR /go/src/coupon-service
+
+WORKDIR /go/src
 
 COPY . .
 
-WORKDIR /go/src/coupon-service/cmd/export
-RUN go build -o main .
+WORKDIR /go/src
+RUN go build -o main ./cmd/coupon_service/main.go
 
 ENTRYPOINT ./main
 EXPOSE 8080

--- a/review/cmd/coupon_service/main.go
+++ b/review/cmd/coupon_service/main.go
@@ -6,6 +6,8 @@ import (
 	"coupon_service/internal/repository/memdb"
 	"coupon_service/internal/service"
 	"fmt"
+
+	// "runtime"
 	"time"
 )
 
@@ -14,12 +16,21 @@ var (
 	repo = memdb.New()
 )
 
+// func init() {
+// 	if runtime.NumCPU() != 32 {
+// 		panic("this api is meant to be run on 32 core machines")
+// 	}
+// }
+
 func main() {
 	svc := service.New(repo)
-	本 := api.New(cfg.API, svc)
-	本.Start()
+	newAPI := api.New(cfg.API, svc)
+	defer newAPI.Close()
+
 	fmt.Println("Starting Coupon service server")
+	newAPI.Start()
+
 	<-time.After(1 * time.Hour * 24 * 365)
 	fmt.Println("Coupon service server alive for a year, closing")
-	本.Close()
+	newAPI.Close()
 }

--- a/review/cmd/coupon_service/main.go
+++ b/review/cmd/coupon_service/main.go
@@ -6,8 +6,6 @@ import (
 	"coupon_service/internal/repository/memdb"
 	"coupon_service/internal/service"
 	"fmt"
-
-	"runtime"
 	"time"
 )
 
@@ -15,12 +13,6 @@ var (
 	cfg  = config.New()
 	repo = memdb.New()
 )
-
-func init() {
-	if runtime.NumCPU() != 32 {
-		panic("this api is meant to be run on 32 core machines")
-	}
-}
 
 func main() {
 	svc := service.New(repo)

--- a/review/cmd/coupon_service/main.go
+++ b/review/cmd/coupon_service/main.go
@@ -7,7 +7,7 @@ import (
 	"coupon_service/internal/service"
 	"fmt"
 
-	// "runtime"
+	"runtime"
 	"time"
 )
 
@@ -16,11 +16,11 @@ var (
 	repo = memdb.New()
 )
 
-// func init() {
-// 	if runtime.NumCPU() != 32 {
-// 		panic("this api is meant to be run on 32 core machines")
-// 	}
-// }
+func init() {
+	if runtime.NumCPU() != 32 {
+		panic("this api is meant to be run on 32 core machines")
+	}
+}
 
 func main() {
 	svc := service.New(repo)

--- a/review/internal/api/api.go
+++ b/review/internal/api/api.go
@@ -47,7 +47,7 @@ func (a API) withServer() API {
 	ch := make(chan API)
 	go func() {
 		a.srv = &http.Server{
-			Addr:    fmt.Sprintf(":%d", a.CFG.Port),
+			Addr:    fmt.Sprintf("%s:%d", a.CFG.Host, a.CFG.Port),
 			Handler: a.MUX,
 		}
 		ch <- a
@@ -58,16 +58,19 @@ func (a API) withServer() API {
 
 func (a API) withRoutes() API {
 	apiGroup := a.MUX.Group("/api")
-	apiGroup.POST("/apply", a.Apply)
-	apiGroup.POST("/create", a.Create)
-	apiGroup.GET("/coupons", a.Get)
+	couponApiGroup := apiGroup.Group("/coupon")
+	couponApiGroup.POST("/apply", a.Apply)
+	couponApiGroup.POST("/create", a.Create)
+	couponApiGroup.GET("/list", a.Get)
 	return a
 }
 
 func (a API) Start() {
-	if err := a.srv.ListenAndServe(); err != nil {
-		log.Fatal(err)
-	}
+	// Since we are using gin gonic, it makes sense to use the Run function
+	// for the gin engine.
+	// Also we init the routes.
+	a.withRoutes()
+	a.MUX.Run(a.srv.Addr)
 }
 
 func (a API) Close() {

--- a/review/internal/api/coupon.go
+++ b/review/internal/api/coupon.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	. "coupon_service/internal/api/entity"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -39,6 +40,8 @@ func (a *API) Get(c *gin.Context) {
 	}
 	coupons, err := a.svc.GetCoupons(apiReq.Codes)
 	if err != nil {
+		log.Printf("Error when getting coupons: %v", err)
+		c.JSON(http.StatusOK, coupons)
 		return
 	}
 	c.JSON(http.StatusOK, coupons)

--- a/review/internal/api/coupon.go
+++ b/review/internal/api/coupon.go
@@ -15,6 +15,7 @@ func (a *API) Apply(c *gin.Context) {
 	}
 	basket, err := a.svc.ApplyCoupon(apiReq.Basket, apiReq.Code)
 	if err != nil {
+		c.JSON(http.StatusBadRequest, err)
 		return
 	}
 
@@ -28,6 +29,7 @@ func (a *API) Create(c *gin.Context) {
 	}
 	err := a.svc.CreateCoupon(apiReq.Discount, apiReq.Code, apiReq.MinBasketValue)
 	if err != nil {
+		c.JSON(http.StatusBadRequest, err)
 		return
 	}
 	c.Status(http.StatusOK)
@@ -41,7 +43,8 @@ func (a *API) Get(c *gin.Context) {
 	coupons, err := a.svc.GetCoupons(apiReq.Codes)
 	if err != nil {
 		log.Printf("Error when getting coupons: %v", err)
-		c.JSON(http.StatusOK, coupons)
+		// We can change this to status code
+		c.JSON(http.StatusBadRequest, coupons)
 		return
 	}
 	c.JSON(http.StatusOK, coupons)

--- a/review/internal/config/config.go
+++ b/review/internal/config/config.go
@@ -12,7 +12,12 @@ type Config struct {
 }
 
 func New() Config {
-	cfg := Config{}
+	cfg := Config{
+		API: api.Config{
+			Host: "127.0.0.1",
+			Port: 8080,
+		},
+	}
 	if err := alligotor.Get(&cfg); err != nil {
 		log.Fatal(err)
 	}

--- a/review/internal/repository/memdb/memdb.go
+++ b/review/internal/repository/memdb/memdb.go
@@ -17,13 +17,13 @@ type Repository struct {
 }
 
 func New() *Repository {
-	return &Repository{}
+	return &Repository{entries: make(map[string]entity.Coupon)}
 }
 
 func (r *Repository) FindByCode(code string) (*entity.Coupon, error) {
 	coupon, ok := r.entries[code]
 	if !ok {
-		return nil, fmt.Errorf("Coupon not found")
+		return nil, fmt.Errorf("coupon not found")
 	}
 	return &coupon, nil
 }

--- a/review/internal/repository/memdb/memdb.go
+++ b/review/internal/repository/memdb/memdb.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 )
 
-type Config struct{}
-
 type repository interface {
 	FindByCode(string) (*entity.Coupon, error)
 	Save(entity.Coupon) error

--- a/review/internal/service/entity/basket.go
+++ b/review/internal/service/entity/basket.go
@@ -1,9 +1,5 @@
 package entity
 
-import (
-	_ "github.com/gin-gonic/gin"
-)
-
 type Basket struct {
 	Value                 int
 	AppliedDiscount       int

--- a/review/internal/service/entity/basket.go
+++ b/review/internal/service/entity/basket.go
@@ -1,7 +1,7 @@
 package entity
 
 type Basket struct {
-	Value                 int
+	Value                 float64
 	AppliedDiscount       int
 	ApplicationSuccessful bool
 }

--- a/review/internal/service/entity/coupon.go
+++ b/review/internal/service/entity/coupon.go
@@ -1,13 +1,5 @@
 package entity
 
-import "runtime"
-
-func init() {
-	if 32 != runtime.NumCPU() {
-		panic("this api is meant to be run on 32 core machines")
-	}
-}
-
 type Coupon struct {
 	ID             string
 	Code           string

--- a/review/internal/service/service.go
+++ b/review/internal/service/service.go
@@ -29,6 +29,10 @@ func (s Service) ApplyCoupon(basket Basket, code string) (b *Basket, e error) {
 		return nil, err
 	}
 
+	if b.ApplicationSuccessful {
+		return nil, fmt.Errorf("discount has been already applied")
+	}
+
 	if b.Value > 0 {
 		b.Value = b.Value * (coupon.Discount / 100)
 		b.AppliedDiscount = coupon.Discount

--- a/review/internal/service/service.go
+++ b/review/internal/service/service.go
@@ -30,14 +30,13 @@ func (s Service) ApplyCoupon(basket Basket, code string) (b *Basket, e error) {
 	}
 
 	if b.Value > 0 {
+		b.Value = b.Value * (coupon.Discount / 100)
 		b.AppliedDiscount = coupon.Discount
 		b.ApplicationSuccessful = true
-	}
-	if b.Value == 0 {
-		return
+		return b, nil
 	}
 
-	return nil, fmt.Errorf("Tried to apply discount to negative value")
+	return nil, fmt.Errorf("discount value cannot be zero")
 }
 
 func (s Service) CreateCoupon(discount int, code string, minBasketValue int) any {
@@ -66,6 +65,7 @@ func (s Service) GetCoupons(codes []string) ([]Coupon, error) {
 			} else {
 				e = fmt.Errorf("%w; code: %s, index: %d", e, code, idx)
 			}
+			continue
 		}
 		coupons = append(coupons, *coupon)
 	}

--- a/review/internal/service/service.go
+++ b/review/internal/service/service.go
@@ -29,12 +29,12 @@ func (s Service) ApplyCoupon(basket Basket, code string) (b *Basket, e error) {
 		return nil, err
 	}
 
-	if b.ApplicationSuccessful {
-		return nil, fmt.Errorf("discount has been already applied")
+	if coupon.MinBasketValue > int(b.Value) {
+		return nil, fmt.Errorf("basket value does not reach minimum value")
 	}
 
 	if b.Value > 0 {
-		b.Value = b.Value * (coupon.Discount / 100)
+		b.Value = b.Value * (1 - float64(coupon.Discount)/100)
 		b.AppliedDiscount = coupon.Discount
 		b.ApplicationSuccessful = true
 		return b, nil

--- a/review/internal/service/service_test.go
+++ b/review/internal/service/service_test.go
@@ -41,12 +41,17 @@ func TestService_ApplyCoupon(t *testing.T) {
 		args    args
 		wantB   *entity.Basket
 		wantErr bool
-	}{}
+	}{
+		{"Apply 10%", fields{memdb.New()}, args{entity.Basket{Value: 16}, "DiscountCode"}, &entity.Basket{Value: 14.4, AppliedDiscount: 10, ApplicationSuccessful: true}, false},
+		{"Apply 10%", fields{memdb.New()}, args{entity.Basket{Value: 14}, "DiscountCode"}, nil, true},
+		{"Apply 10%", fields{memdb.New()}, args{entity.Basket{Value: 0}, "DiscountCode"}, nil, true},
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Service{
 				repo: tt.fields.repo,
 			}
+			s.CreateCoupon(10, tt.args.code, 15)
 			gotB, err := s.ApplyCoupon(tt.args.basket, tt.args.code)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ApplyCoupon() error = %v, wantErr %v", err, tt.wantErr)

--- a/review/internal/service/service_test.go
+++ b/review/internal/service/service_test.go
@@ -91,3 +91,38 @@ func TestService_CreateCoupon(t *testing.T) {
 		})
 	}
 }
+
+func TestService_GetCoupons(t *testing.T) {
+	type fields struct {
+		repo Repository
+	}
+	type args struct {
+		discount       int
+		code           string
+		minBasketValue int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{"Apply 10%", fields{memdb.New()}, args{10, "Superdiscount", 55}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Service{
+				repo: tt.fields.repo,
+			}
+
+			s.CreateCoupon(tt.args.discount, tt.args.code, tt.args.minBasketValue)
+			coupons, err := s.GetCoupons([]string{tt.args.code})
+			if len(coupons) > 1 {
+				t.Errorf("GetCoupons() should return one coupon")
+			}
+			if err != nil {
+				t.Errorf("ApplyCoupon() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### WHY, WHAT 


-  Remove the runtime init function form entity coupon and pass it to` main.go`
- In `main.go` - Remove symbol name and put an English variable name. 
- In `main.go` move `newAPi.Start() `
- Fixed `Dockerfile`, also considered creating a docker-compose file. 
- In `config.go` we are not setting any ports or host. 
- In `api.go` we need to fix the `Start()` function to actually run the gin engine. 

   a. I initialised the routes (the function was never used, so there was no way to actually access those routes) -> `a.withRoutes() `
   b. Since we are using gin gonic, I started the server by using :` a.MUX.Run()` . So accessing the gin engine and using the method `Run()` to actually serve it. 

- As  per route naming conventions, I would change the names to noun/verb and use singular So for example, instead of just using “/create” I would have “/coupon/create” and “coupons” to “coupon/list”

- in api/coupon.go Handled bad requests when having errors. 

- Change Basket value to float
- Create Coupon:  in `memdb.go` -> Should initialise r.entries to avoid “assignment to entry in nil map” panic error > I choose to add it when initialising the repo. :  `&Repository{entries: make(map[string]entity.Coupon)}` 
       > Suggestion: Status code to 201, as we are creating a new instance
       > At the moment if we have the same code, the coupon will be overwritten, but it would suggest  returning an error message because the coupon already exists. 
       
- Get Coupons: in `service.go `method `GetCoupons() `:  > when the repo returns an error for `FindByCode()` we either need to return the error, or put a “continue” in there, so we can check the next code. In this scenario, we don’t need to pass to appending coupons. It Will go into panic error (invalid memory address or nil pointer dereference), and even if it wouldn’t it does not make sense to actually append anything at this point. So we better throw an error or a continue (and of course have the log for the error)
 > When having a Coupon not found error:   We either decide to return error and end the loop and maybe even return a server error, or we could just decide to go on and just log the not found coupons. I Think it is more reasonable the second one. So I decided to just have the logs in api.go and the endpoint would still return a 200 status code, but with these logs:
<img width="542" alt="Screenshot 2024-05-07 at 14 31 37" src="https://github.com/eljoth/go-code-review/assets/18722673/c697cb95-5da3-4e42-b539-6d6ff76ffc5c">

- In `ApplyCoupon()` method in service.go 
 > we are not actually applying the discount of the coupon. It is safe to assume that the discount integer is representing a percentage of the discount, we calculate it by the formula: ` b.Value = b.Value * (1- coupon.Discount/100)` 
 > Removed the last condition (not needed when returning basket inside the first condition)
 > If the value is lower than miniBasketValue for coupon, then we cannot apply the coupon
 
- In` service_test.go`  
> We are missing the test for get coupons.
> TestService_ApplyCoupon is not doing anything. It is not entering the loop since we only have declared the tests structs but not actually set values 

- Maybe also add tests for the api calls. 
